### PR TITLE
feat: add the Reason parameter in on offline and gone hooks

### DIFF
--- a/src/on_client_gone_hook.erl
+++ b/src/on_client_gone_hook.erl
@@ -3,4 +3,4 @@
 -include("vernemq_dev.hrl").
 
 %% called as an 'all'-hook, return value is ignored
--callback on_client_gone(SubscriberId  :: subscriber_id()) -> any().
+-callback on_client_gone(SubscriberId  :: subscriber_id(), Reason :: atom()) -> any().

--- a/src/on_client_offline_hook.erl
+++ b/src/on_client_offline_hook.erl
@@ -3,4 +3,4 @@
 -include("vernemq_dev.hrl").
 
 %% called as an 'all'-hook, return value is ignored
--callback on_client_offline(SubscriberId  :: subscriber_id()) -> any().
+-callback on_client_offline(SubscriberId  :: subscriber_id(), Reason :: atom()) -> any().


### PR DESCRIPTION
Added the `Reason` parameter of type `atom()` to the `on_client_offline` and `on_client_gone` callback function. The `Reason` parameter is used to provide additional information about the client's disconnection reason when the callback is triggered.